### PR TITLE
Adds temporary fix to Carousel

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -45,8 +45,8 @@ function Carousel() {
         ))}
       </div>
       <div className="carousel-cards">
-        {topics[activeIndex].cards.map((card, index) => (
-          <div key={index} className="card">
+        {topics[activeIndex]?.cards?.map((card, index) => (
+          <div key={index} className={card ? "card" : ""}>
             {/* Conteúdo do card */}
           </div>
         ))}


### PR DESCRIPTION
In order to allow temporary availability to the app at Netlify, I propose these changes to fix the given errors:


"Address the TypeScript errors in the file "src/components/Carousel/index.tsx":
TS2532 error at line 48, where an object is possibly 'undefined'.
TS6133 error at line 48, where the variable 'card' is declared but its value is never read."